### PR TITLE
fix: respecting initial value from formbuilder map when field misses initial value

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -213,7 +213,11 @@ class FormBuilderState extends State<FormBuilder> {
 
     _fields[name] = field;
     field.registerTransformer(_transformers);
-    _instantValue[name] = field.initialValue;
+
+    field.setValue(
+      (_instantValue[name] = field.initialValue ?? _instantValue[name]),
+      populateForm: false,
+    );
   }
 
   void unregisterField(String name, FormBuilderFieldState field) {


### PR DESCRIPTION
Task #1388